### PR TITLE
Fix copyright statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2015 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # p9p
 A modern, performant 9P library for Go
+
+## Copyright and license
+
+Copyright © 2015 Docker, Inc. go-p9p is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.


### PR DESCRIPTION
Removes placeholder, and adds basic copyright/license section to the README
