### PR TITLE
readme: add link to GoDoc in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # p9p
-A modern, performant 9P library for Go
 
 [![GoDoc](https://godoc.org/github.com/docker/go-p9p?status.svg)](https://godoc.org/github.com/docker/go-p9p)
 [![CircleCI](https://circleci.com/gh/docker/go-p9p.svg?style=shield)](https://circleci.com/gh/docker/go-p9p)
+
+A modern, performant 9P library for Go.
+
+For information on usage, please see the [GoDoc](https://godoc.org/github.com/docker/go-p9p).
 
 ## Copyright and license
 


### PR DESCRIPTION
Upon further examination, the GoDoc is a very good source of
documentation for this package. Send users there for now.

Signed-off-by: Stephen J Day <stephen.day@docker.com>