### PR TITLE
client: log messages with unknown tags

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -170,7 +170,12 @@ func (t *transport) handle() {
 		case b := <-responses:
 			req, ok := outstanding[b.Tag]
 			if !ok {
-				panic("unknown tag received")
+				// BUG(stevvooe): The exact handling of an unknown tag is
+				// unclear at this point. These may not necessarily fatal to
+				// the session, since they could be messages that the client no
+				// longer cares for. When we figure this out, replace this
+				// panic with something more sensible.
+				panic(fmt.Sprintf("unknown tag received: %v", b))
 			}
 
 			// BUG(stevvooe): Must detect duplicate tag and ensure that we are


### PR DESCRIPTION
Several clients have experienced panics after receiving unknown tags.
The exact cause of these unknown messages is unknown. It is also not
clear whether an unknown tag should be fatal to the session.

This change provides more information in the panic message which we can
then use to better understand this condition.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Related to #2 