### PR TITLE
respect the msize value for read/write

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -35,6 +35,9 @@ type Channel interface {
 	// SetMSize sets the maximum message size for the channel. This must never
 	// be called currently with ReadFcall or WriteFcall.
 	SetMSize(msize int)
+
+	// Codec gets the codec used to for calls marshalling
+	Codec() Codec
 }
 
 // NewChannel returns a new channel to read and write Fcalls with the provided
@@ -186,6 +189,10 @@ func (ch *channel) WriteFcall(ctx context.Context, fcall *Fcall) error {
 	}
 
 	return ch.bwr.Flush()
+}
+
+func (ch *channel) Codec() Codec {
+	return ch.codec
 }
 
 // readmsg reads a 9p message into p from rd, ensuring that all bytes are

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ type client struct {
 // a context for out of bad messages, such as flushes, that may be sent by the
 // session. The session can effectively shutdown with this context.
 func NewSession(ctx context.Context, conn net.Conn) (Session, error) {
-	ch := newChannel(conn, codec9p{}, DefaultMSize) // sets msize, effectively.
+	ch := newChannelWithDefaultCodec(conn, DefaultMSize)
 
 	// negotiate the protocol version
 	version, err := clientnegotiate(ctx, ch, DefaultVersion)

--- a/client.go
+++ b/client.go
@@ -236,3 +236,7 @@ func (c *client) WStat(ctx context.Context, fid Fid, dir Dir) error {
 
 	return nil
 }
+
+func (c *client) Codec() Codec {
+	return c.transport.codec()
+}

--- a/client.go
+++ b/client.go
@@ -135,70 +135,39 @@ func (c *client) Walk(ctx context.Context, fid Fid, newfid Fid, names ...string)
 }
 
 func (c *client) Read(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error) {
-	// size[4] Rread tag[2] count[4] data[count]
-	const rreadMessageEnvelopeSize int = 4 + 1 + 2 + 4
-
-	maxChunkSize := c.msize - rreadMessageEnvelopeSize
-	totalRead := 0
-
-	for {
-		remaining := len(p) - totalRead
-		toRead := min(maxChunkSize, remaining)
-		resp, err := c.transport.send(ctx, MessageTread{
-			Fid:    fid,
-			Offset: uint64(offset + int64(totalRead)),
-			Count:  uint32(toRead),
-		})
-		if err != nil {
-			return 0, err
-		}
-
-		rread, ok := resp.(MessageRread)
-		if !ok {
-			return 0, ErrUnexpectedMsg
-		}
-		copy(p[totalRead:], rread.Data)
-
-		totalRead += len(rread.Data)
-
-		// read end or eof
-		if totalRead == len(p) || toRead > len(rread.Data) {
-			break
-		}
+	resp, err := c.transport.send(ctx, MessageTread{
+		Fid:    fid,
+		Offset: uint64(offset),
+		Count:  uint32(len(p)),
+	})
+	if err != nil {
+		return 0, err
 	}
 
-	return totalRead, nil
+	rread, ok := resp.(MessageRread)
+	if !ok {
+		return 0, ErrUnexpectedMsg
+	}
+
+	return copy(p, rread.Data), nil
 }
 
 func (c *client) Write(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error) {
-	// size[4] Twrite tag[2] fid[4] offset[8] count[4] data[count]
-	const twriteMessageEnvelopeSize int = 4 + 1 + 2 + 4 + 8 + 4
-	maxChunkSize := c.msize - twriteMessageEnvelopeSize
-	totalWritten := 0
-	for {
-		remaining := len(p) - totalWritten
-		toWrite := min(maxChunkSize, remaining)
-		resp, err := c.transport.send(ctx, MessageTwrite{
-			Fid:    fid,
-			Offset: uint64(offset + int64(totalWritten)),
-			Data:   p[totalWritten : totalWritten+toWrite],
-		})
-		if err != nil {
-			return 0, err
-		}
-
-		rwrite, ok := resp.(MessageRwrite)
-		if !ok {
-			return 0, ErrUnexpectedMsg
-		}
-
-		totalWritten += int(rwrite.Count)
-		if totalWritten == len(p) {
-			break
-		}
+	resp, err := c.transport.send(ctx, MessageTwrite{
+		Fid:    fid,
+		Offset: uint64(offset),
+		Data:   p,
+	})
+	if err != nil {
+		return 0, err
 	}
 
-	return int(totalWritten), nil
+	rwrite, ok := resp.(MessageRwrite)
+	if !ok {
+		return 0, ErrUnexpectedMsg
+	}
+
+	return int(rwrite.Count), nil
 }
 
 func (c *client) Open(ctx context.Context, fid Fid, mode Flag) (Qid, uint32, error) {
@@ -266,11 +235,4 @@ func (c *client) WStat(ctx context.Context, fid Fid, dir Dir) error {
 	}
 
 	return nil
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/cmd/9pr/main.go
+++ b/cmd/9pr/main.go
@@ -203,7 +203,7 @@ func (c *fsCommander) cmdls(ctx context.Context, args ...string) error {
 		}
 
 		rd := bytes.NewReader(p[:n])
-		codec := p9p.NewCodec() // TODO(stevvooe): Need way to resolve codec based on session.
+		codec := c.session.Codec()
 		for {
 			var d p9p.Dir
 			if err := p9p.DecodeDir(codec, rd, &d); err != nil {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
-	codec := NewCodec()
+	codec := NewCodec(100 * 1024)
 	for _, testcase := range []struct {
 		description string
 		target      interface{}

--- a/filereader.go
+++ b/filereader.go
@@ -1,8 +1,9 @@
 package p9p
 
 import (
-	"context"
 	"io"
+
+	"golang.org/x/net/context"
 )
 
 type fileReader struct {

--- a/filereader.go
+++ b/filereader.go
@@ -1,0 +1,31 @@
+package p9p
+
+import (
+	"context"
+	"io"
+)
+
+type fileReader struct {
+	session Session
+	ctx     context.Context
+	fid     Fid
+	offset  int64
+}
+
+// NewFileReader creates an io.Reader wrapper for reading a 9p session file
+func NewFileReader(s Session, ctx context.Context, fid Fid, readAt int64) io.Reader {
+	return &fileReader{s, ctx, fid, readAt}
+}
+
+func (r *fileReader) Read(p []byte) (n int, err error) {
+	n, err = r.session.Read(r.ctx, r.fid, p, r.offset)
+	r.offset += int64(n)
+	// additional error handling for compliying with io.Reader
+	if n == 0 && (err == nil || err == io.EOF) {
+		err = io.ErrUnexpectedEOF
+	}
+	if n < len(p) && err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}

--- a/filewriter.go
+++ b/filewriter.go
@@ -1,8 +1,9 @@
 package p9p
 
 import (
-	"context"
 	"io"
+
+	"golang.org/x/net/context"
 )
 
 type fileWriter struct {

--- a/filewriter.go
+++ b/filewriter.go
@@ -1,0 +1,32 @@
+package p9p
+
+import (
+	"context"
+	"io"
+)
+
+type fileWriter struct {
+	session Session
+	ctx     context.Context
+	fid     Fid
+	offset  int64
+}
+
+// NewFileWriter creates an io.Writer wrapper for writing on a 9p session file
+func NewFileWriter(s Session, ctx context.Context, fid Fid, writeAt int64) io.Writer {
+	return &fileWriter{s, ctx, fid, writeAt}
+}
+
+func (w *fileWriter) Write(p []byte) (n int, err error) {
+	for err == nil {
+		var written int
+		written, err = w.session.Write(w.ctx, w.fid, p, w.offset)
+		p = p[written:]
+		w.offset += int64(written)
+		n += written
+		if len(p) == 0 {
+			break
+		}
+	}
+	return
+}

--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ func ServeConn(ctx context.Context, cn net.Conn, handler Handler) error {
 	// we want to proxy version and message size decisions all the back to the
 	// origin server or make those decisions at each link of a proxy chain.
 
-	ch := newChannel(cn, codec9p{}, DefaultMSize)
+	ch := newChannelWithDefaultCodec(cn, DefaultMSize)
 	negctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 

--- a/session.go
+++ b/session.go
@@ -31,30 +31,3 @@ type Session interface {
 	// session implementation.
 	Version() (msize int, version string)
 }
-
-// WriteFull writes the whole p slice to the specified fid
-func WriteFull(s Session, ctx context.Context, fid Fid, p []byte, offset int64) error {
-	for len(p) > 0 {
-		written, err := s.Write(ctx, fid, p, offset)
-		if err != nil {
-			return err
-		}
-		p = p[written:]
-		offset += int64(written)
-	}
-	return nil
-}
-
-// ReadFull reads the whole file and returns it in a slice
-func ReadFull(s Session, ctx context.Context, fid Fid, offset int64) (p []byte, err error) {
-	var buf [4096]byte
-	for {
-		var read int
-		read, err = s.Read(ctx, fid, buf[:], offset)
-		if err != nil || read == 0 { // error or eof
-			return
-		}
-		p = append(p, buf[:read]...)
-		offset += int64(read)
-	}
-}

--- a/session.go
+++ b/session.go
@@ -30,4 +30,5 @@ type Session interface {
 	// can be affected by negotiating or the level of support provided by the
 	// session implementation.
 	Version() (msize int, version string)
+	Codec() Codec
 }

--- a/session.go
+++ b/session.go
@@ -31,3 +31,30 @@ type Session interface {
 	// session implementation.
 	Version() (msize int, version string)
 }
+
+// WriteFull writes the whole p slice to the specified fid
+func WriteFull(s Session, ctx context.Context, fid Fid, p []byte, offset int64) error {
+	for len(p) > 0 {
+		written, err := s.Write(ctx, fid, p, offset)
+		if err != nil {
+			return err
+		}
+		p = p[written:]
+		offset += int64(written)
+	}
+	return nil
+}
+
+// ReadFull reads the whole file and returns it in a slice
+func ReadFull(s Session, ctx context.Context, fid Fid, offset int64) (p []byte, err error) {
+	var buf [4096]byte
+	for {
+		var read int
+		read, err = s.Read(ctx, fid, buf[:], offset)
+		if err != nil || read == 0 { // error or eof
+			return
+		}
+		p = append(p, buf[:read]...)
+		offset += int64(read)
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -16,6 +16,7 @@ import (
 // serialization.
 type roundTripper interface {
 	send(ctx context.Context, msg Message) (Message, error)
+	codec() Codec
 }
 
 // transport plays the role of being a client channel manager. It multiplexes
@@ -99,6 +100,10 @@ func (t *transport) send(ctx context.Context, msg Message) (Message, error) {
 
 		return resp.Message, nil
 	}
+}
+
+func (t *transport) codec() Codec {
+	return t.ch.Codec()
 }
 
 // allocateTag returns a valid tag given a tag pool map. It receives a hint as

--- a/version.go
+++ b/version.go
@@ -38,7 +38,8 @@ func clientnegotiate(ctx context.Context, ch Channel, version string) (string, e
 			return "", fmt.Errorf("unsupported server version: %v", version)
 		}
 
-		if int(v.MSize) > ch.MSize() {
+		if int(v.MSize) < ch.MSize() {
+			// msize negociation rule is simple : the lowest msize from either the client or the server rules
 			// upgrade msize if server differs.
 			ch.SetMSize(int(v.MSize))
 		}

--- a/version.go
+++ b/version.go
@@ -38,8 +38,7 @@ func clientnegotiate(ctx context.Context, ch Channel, version string) (string, e
 			return "", fmt.Errorf("unsupported server version: %v", version)
 		}
 
-		if int(v.MSize) < ch.MSize() {
-			// msize negociation rule is simple : the lowest msize from either the client or the server rules
+		if int(v.MSize) > ch.MSize() {
 			// upgrade msize if server differs.
 			ch.SetMSize(int(v.MSize))
 		}


### PR DESCRIPTION
There was a typo in the msize negociation code, and for large read / writes, the msize value was not taken into account (if the size of the data to write + size of the header message > msize, we must chunk the data)