### PR TITLE
Fixes the MSize comparison when negociating msize with server

### DIFF
--- a/version.go
+++ b/version.go
@@ -38,7 +38,7 @@ func clientnegotiate(ctx context.Context, ch Channel, version string) (string, e
 			return "", fmt.Errorf("unsupported server version: %v", version)
 		}
 
-		if int(v.MSize) > ch.MSize() {
+		if int(v.MSize) < ch.MSize() {
 			// upgrade msize if server differs.
 			ch.SetMSize(int(v.MSize))
 		}


### PR DESCRIPTION
The msize negociation was wrong.
According to the man page http://plan9.bell-labs.com/magic/man2html/5/version, and Linux kernel 9pfs implementation http://git.kernel.org/cgit/linux/kernel/git/ericvh/v9fs.git/tree/net/9p/client.c#n980, the flow of version is:

- client send its "HARD" max size
- server compare it to its own "HARD" max size and respond with the minimum of the 2 values
-> in the response the msize cannot be greater than the original client max size (if server has a greater value, it scales down to full fill the client constraint, if its lower, it tells to the client that it can't accept such a large msize value)
- client and server agrees to scale down to the lowest "Hard" max size