### PR TITLE
Expose max message sizes and check boundaries on Read/Write

### DIFF
--- a/filereader.go
+++ b/filereader.go
@@ -1,0 +1,36 @@
+package p9p
+
+import (
+	"io"
+
+	"golang.org/x/net/context"
+)
+
+type fileReader struct {
+	session Session
+	ctx     context.Context
+	fid     Fid
+	offset  int64
+}
+
+// NewFileReader creates an io.Reader wrapper for reading a 9p session file
+func NewFileReader(s Session, ctx context.Context, fid Fid, readAt int64) io.Reader {
+	return &fileReader{s, ctx, fid, readAt}
+}
+
+func (r *fileReader) Read(p []byte) (n int, err error) {
+	if len(p) > r.session.MaxReadSize() {
+		p = p[:r.session.MaxReadSize()]
+	}
+	n, err = r.session.Read(r.ctx, r.fid, p, r.offset)
+	r.offset += int64(n)
+	// additional error handling for compliying with io.Reader
+	if n == 0 && (err == nil) {
+		err = io.EOF
+		return
+	}
+	if n < len(p) && err == nil || err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}

--- a/filereader.go
+++ b/filereader.go
@@ -25,12 +25,8 @@ func (r *fileReader) Read(p []byte) (n int, err error) {
 	n, err = r.session.Read(r.ctx, r.fid, p, r.offset)
 	r.offset += int64(n)
 	// additional error handling for compliying with io.Reader
-	if n == 0 && (err == nil) {
+	if n < len(p) && err == nil {
 		err = io.EOF
-		return
-	}
-	if n < len(p) && err == nil || err == io.EOF {
-		err = io.ErrUnexpectedEOF
 	}
 	return
 }

--- a/filewriter.go
+++ b/filewriter.go
@@ -1,0 +1,40 @@
+package p9p
+
+import (
+	"io"
+
+	"golang.org/x/net/context"
+)
+
+type fileWriter struct {
+	session Session
+	ctx     context.Context
+	fid     Fid
+	offset  int64
+}
+
+// NewFileWriter creates an io.Writer wrapper for writing on a 9p session file
+func NewFileWriter(s Session, ctx context.Context, fid Fid, writeAt int64) io.Writer {
+	return &fileWriter{s, ctx, fid, writeAt}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (w *fileWriter) Write(p []byte) (n int, err error) {
+	for err == nil {
+		var written int
+		written, err = w.session.Write(w.ctx, w.fid, p[:minInt(len(p), w.session.MaxWriteSize())], w.offset)
+		p = p[written:]
+		w.offset += int64(written)
+		n += written
+		if len(p) == 0 {
+			break
+		}
+	}
+	return
+}

--- a/session.go
+++ b/session.go
@@ -19,12 +19,17 @@ type Session interface {
 	Clunk(ctx context.Context, fid Fid) error
 	Remove(ctx context.Context, fid Fid) error
 	Walk(ctx context.Context, fid Fid, newfid Fid, names ...string) ([]Qid, error)
+
+	// Read reads bytes from the file pointed by fid. must have len(p) <= MaxReadSize() overwise err is ErrOverflow
 	Read(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
+	// Write writes bytes to the specified file. must have len(p) <= MaxWriteSize() overwise err is ErrOverflow
 	Write(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
 	Open(ctx context.Context, fid Fid, mode Flag) (Qid, uint32, error)
 	Create(ctx context.Context, parent Fid, name string, perm uint32, mode Flag) (Qid, uint32, error)
 	Stat(ctx context.Context, fid Fid) (Dir, error)
 	WStat(ctx context.Context, fid Fid, dir Dir) error
+	MaxReadSize() int
+	MaxWriteSize() int
 
 	// Version returns the supported version and msize of the session. This
 	// can be affected by negotiating or the level of support provided by the

--- a/transport.go
+++ b/transport.go
@@ -16,6 +16,7 @@ import (
 // serialization.
 type roundTripper interface {
 	send(ctx context.Context, msg Message) (Message, error)
+	channel() Channel
 }
 
 // transport plays the role of being a client channel manager. It multiplexes
@@ -65,7 +66,9 @@ func newFcallRequest(ctx context.Context, msg Message) *fcallRequest {
 		err:      make(chan error, 1),
 	}
 }
-
+func (t *transport) channel() Channel {
+	return t.ch
+}
 func (t *transport) send(ctx context.Context, msg Message) (Message, error) {
 	req := newFcallRequest(ctx, msg)
 


### PR DESCRIPTION
This implements correct msize handling where Read/Write operations cannot read/write more than msize-[message envelope size]  bytes at once.
For easier processing, this behavior is encapsulated in a io.Reader / io.Writer implementation to chunk read and writes when needed.