### PR TITLE
channel: truncate twrite messages based on msize

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,256 @@
+package p9p
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestTwriteOverflow ensures that a Twrite message will have the data field
+// truncated if the msize would be exceeded.
+func TestTwriteOverflow(t *testing.T) {
+	const (
+		msize = 512
+
+		// size[4] Twrite tag[2] fid[4] offset[8] count[4] data[count] | count = 0
+		overhead = 4 + 1 + 2 + 4 + 8 + 4
+	)
+
+	var (
+		ctx  = context.Background()
+		conn = &mockConn{}
+		ch   = NewChannel(conn, msize)
+	)
+
+	for _, testcase := range []struct {
+		name     string
+		overflow int // amount to overflow the message by.
+	}{
+		{
+			name:     "BoundedOverflow",
+			overflow: msize / 2,
+		},
+		{
+			name:     "LargeOverflow",
+			overflow: msize * 3,
+		},
+		{
+			name:     "HeaderOverflow",
+			overflow: overhead,
+		},
+		{
+			name:     "HeaderOffsetOverflow",
+			overflow: overhead - 1,
+		},
+		{
+			name:     "OverflowByOne",
+			overflow: 1,
+		},
+	} {
+
+		t.Run(testcase.name, func(t *testing.T) {
+			var (
+				fcall = overflowMessage(ch.(*channel).codec, msize, testcase.overflow)
+				data  = fcall.Message.(MessageTwrite).Data
+				size  uint32
+			)
+
+			t.Logf("overflow: %v, len(data): %v, expected overflow: %v", testcase.overflow, len(data), overhead+len(data)-msize)
+			conn.buf.Reset()
+			if err := ch.WriteFcall(ctx, fcall); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := binary.Read(bytes.NewReader(conn.buf.Bytes()), binary.LittleEndian, &size); err != nil {
+				t.Fatal(err)
+			}
+
+			if size != msize {
+				t.Fatalf("should have truncated size header: %d != %d", size, msize)
+			}
+
+			if conn.buf.Len() != msize {
+				t.Fatalf("should have truncated message: conn.buf.Len(%v) != msize(%v)", conn.buf.Len(), msize)
+			}
+		})
+	}
+
+}
+
+// TestWriteOverflowError ensures that we return an error in cases when there
+// will certainly be an overflow and it cannot be resolved.
+func TestWriteOverflowError(t *testing.T) {
+	const (
+		msize         = 4
+		overflowMSize = msize + 1
+	)
+
+	var (
+		ctx   = context.Background()
+		conn  = &mockConn{}
+		ch    = NewChannel(conn, msize)
+		data  = bytes.Repeat([]byte{'A'}, 4)
+		fcall = newFcall(1, MessageTwrite{
+			Data: data,
+		})
+		messageSize = 4 + ch.(*channel).codec.Size(fcall)
+	)
+
+	err := ch.WriteFcall(ctx, fcall)
+	if err == nil {
+		t.Fatal("error expected when overflowing message")
+	}
+
+	if Overflow(err) != messageSize-msize {
+		t.Fatalf("overflow should reflect messageSize and msize, %d != %d", Overflow(err), messageSize-msize)
+	}
+}
+
+// TestReadOverflow ensures that messages coming over a network connection do
+// not overflow the msize. Invalid messages will cause `ReadFcall` to return an
+// Overflow error.
+func TestReadFcallOverflow(t *testing.T) {
+	const (
+		msize = 256
+	)
+
+	var (
+		ctx   = context.Background()
+		conn  = &mockConn{}
+		ch    = NewChannel(conn, msize)
+		codec = ch.(*channel).codec
+	)
+
+	for _, testcase := range []struct {
+		name     string
+		overflow int
+	}{
+		{
+			name:     "OverflowByOne",
+			overflow: 1,
+		},
+		{
+			name:     "HeaderOverflow",
+			overflow: overheadMessage(codec, MessageTwrite{}),
+		},
+		{
+			name:     "HeaderOffsetOverflow",
+			overflow: overheadMessage(codec, MessageTwrite{}) - 1,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			fcall := overflowMessage(codec, msize, testcase.overflow)
+
+			// prepare the raw message
+			p, err := ch.(*channel).codec.Marshal(fcall)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// "send" the message into the buffer
+			// this message is crafted to overflow the read buffer.
+			if err := sendmsg(&conn.buf, p); err != nil {
+				t.Fatal(err)
+			}
+
+			var incoming Fcall
+			err = ch.ReadFcall(ctx, &incoming)
+			if err == nil {
+				t.Fatal("expected error on fcall")
+			}
+
+			// sanity check to ensure our test code has the right overflow
+			if testcase.overflow != ch.(*channel).msgmsize(fcall)-msize {
+				t.Fatalf("overflow calculation incorrect: %v != %v", testcase.overflow, ch.(*channel).msgmsize(fcall)-msize)
+			}
+
+			if Overflow(err) != testcase.overflow {
+				t.Fatalf("unexpected overflow on error: %v !=%v", Overflow(err), testcase.overflow)
+			}
+		})
+	}
+}
+
+// TestTreadRewrite ensures that messages that whose response would overflow
+// the msize will have be adjusted before sending.
+func TestTreadRewrite(t *testing.T) {
+	const (
+		msize         = 256
+		overflowMSize = msize + 1
+	)
+
+	var (
+		ctx  = context.Background()
+		conn = &mockConn{}
+		ch   = NewChannel(conn, msize)
+		buf  = make([]byte, overflowMSize)
+		// data  = bytes.Repeat([]byte{'A'}, overflowMSize)
+		fcall = newFcall(1, MessageTread{
+			Count: overflowMSize,
+		})
+		responseMSize = ch.(*channel).msgmsize(newFcall(1, MessageRread{
+			Data: buf,
+		}))
+	)
+
+	if err := ch.WriteFcall(ctx, fcall); err != nil {
+		t.Fatal(err)
+	}
+
+	// just read the message off the buffer
+	n, err := readmsg(&conn.buf, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	*fcall = Fcall{}
+	if err := ch.(*channel).codec.Unmarshal(buf[:n], fcall); err != nil {
+		t.Fatal(err)
+	}
+
+	tread, ok := fcall.Message.(MessageTread)
+	if !ok {
+		t.Fatalf("unexpected message: %v", fcall)
+	}
+
+	if tread.Count != overflowMSize-(uint32(responseMSize)-msize) {
+		t.Fatalf("count not rewritten: %v != %v", tread.Count, overflowMSize-(uint32(responseMSize)-msize))
+	}
+}
+
+type mockConn struct {
+	net.Conn
+	buf bytes.Buffer
+}
+
+func (m mockConn) SetWriteDeadline(t time.Time) error { return nil }
+func (m mockConn) SetReadDeadline(t time.Time) error  { return nil }
+
+func (m *mockConn) Write(p []byte) (int, error) {
+	return m.buf.Write(p)
+}
+
+func (m *mockConn) Read(p []byte) (int, error) {
+	return m.buf.Read(p)
+}
+
+func overheadMessage(codec Codec, msg Message) int {
+	return 4 + codec.Size(newFcall(1, msg))
+}
+
+// overflowMessage returns message that overflows the msize by overflow bytes,
+// returning the message size and the fcall.
+func overflowMessage(codec Codec, msize, overflow int) *Fcall {
+	var (
+		overhead = overheadMessage(codec, MessageTwrite{})
+		data     = bytes.Repeat([]byte{'A'}, (msize-overhead)+overflow)
+		fcall    = newFcall(1, MessageTwrite{
+			Data: data,
+		})
+	)
+
+	return fcall
+}

--- a/overflow.go
+++ b/overflow.go
@@ -1,0 +1,49 @@
+package p9p
+
+import "fmt"
+
+// Overflow will return a positive number, indicating there was an overflow for
+// the error.
+func Overflow(err error) int {
+	if of, ok := err.(overflow); ok {
+		return of.Size()
+	}
+
+	// traverse cause, if above fails.
+	if causal, ok := err.(interface {
+		Cause() error
+	}); ok {
+		return Overflow(causal.Cause())
+	}
+
+	return 0
+}
+
+// overflow is a resolvable error type that can help callers negotiate
+// session msize. If this error is encountered, no message was sent.
+//
+// The return value of `Size()` represents the number of bytes that would have
+// been truncated if the message were sent. This IS NOT the optimal buffer size
+// for operations like read and write.
+//
+// In the case of `Twrite`, the caller can Size() from the local size to get an
+// optimally size buffer or the write can simply be truncated to `len(buf) -
+// err.Size()`.
+//
+// For the most part, no users of this package should see this error in
+// practice. If this escapes the Session interface, it is a bug.
+type overflow interface {
+	Size() int // number of bytes overflowed.
+}
+
+type overflowErr struct {
+	size int // number of bytes overflowed
+}
+
+func (o overflowErr) Error() string {
+	return fmt.Sprintf("message overflowed %d bytes", o.size)
+}
+
+func (o overflowErr) Size() int {
+	return o.size
+}

--- a/server.go
+++ b/server.go
@@ -132,6 +132,9 @@ func (c *conn) serve() error {
 				}
 
 				go func(ctx context.Context, req *Fcall) {
+					// TODO(stevvooe): Re-write incoming Treads so that handler
+					// can always respond with a message of the correct msize.
+
 					var resp *Fcall
 					msg, err := c.handler.Handle(ctx, req.Message)
 					if err != nil {
@@ -208,6 +211,11 @@ func (c *conn) write(responses chan *Fcall) {
 	for {
 		select {
 		case resp := <-responses:
+			// TODO(stevvooe): Correctly protect againt overflowing msize from
+			// handler. This can be done above, in the main message handler
+			// loop, by adjusting incoming Tread calls to have a Count that
+			// won't overflow the msize.
+
 			if err := c.ch.WriteFcall(c.ctx, resp); err != nil {
 				if err, ok := err.(net.Error); ok {
 					if err.Timeout() || err.Temporary() {

--- a/session.go
+++ b/session.go
@@ -19,8 +19,17 @@ type Session interface {
 	Clunk(ctx context.Context, fid Fid) error
 	Remove(ctx context.Context, fid Fid) error
 	Walk(ctx context.Context, fid Fid, newfid Fid, names ...string) ([]Qid, error)
+
+	// Read follows the semantics of io.ReaderAt.ReadAtt method except it takes
+	// a contxt and Fid.
 	Read(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
+
+	// Write follows the semantics of io.WriterAt.WriteAt except takes a context and an Fid.
+	//
+	// If n == len(p), no error is returned.
+	// If n < len(p), io.ErrShortWrite will be returned.
 	Write(ctx context.Context, fid Fid, p []byte, offset int64) (n int, err error)
+
 	Open(ctx context.Context, fid Fid, mode Flag) (Qid, uint32, error)
 	Create(ctx context.Context, parent Fid, name string, perm uint32, mode Flag) (Qid, uint32, error)
 	Stat(ctx context.Context, fid Fid) (Dir, error)


### PR DESCRIPTION
While there are a few problems around handling of msize, the easiest to
address and, arguably, the most problematic is that of Twrite. We now
truncate Twrite.Data to the correct length if it will overflow the msize
limit negotiated on the session.

Other problems with Twrite/Rread are documented in TODOs here, along
with possible solutions.

Signed-off-by: Stephen J Day stephen.day@docker.com
