### PR TITLE
Clean up logging

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -136,7 +136,7 @@ func (ch *channel) ReadFcall(ctx context.Context, fcall *Fcall) error {
 	}
 
 	if err := ch.conn.SetReadDeadline(deadline); err != nil {
-		log.Printf("transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
+		log.Printf("p9p: transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
 	}
 
 	n, err := readmsg(ch.brd, ch.rdbuf)
@@ -184,7 +184,7 @@ func (ch *channel) WriteFcall(ctx context.Context, fcall *Fcall) error {
 	}
 
 	if err := ch.conn.SetWriteDeadline(deadline); err != nil {
-		log.Printf("transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
+		log.Printf("p9p: transport: error setting read deadline on %v: %v", ch.conn.RemoteAddr(), err)
 	}
 
 	if err := ch.maybeTruncate(fcall); err != nil {

--- a/encoding.go
+++ b/encoding.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"reflect"
 	"strings"
 	"time"
@@ -330,9 +329,7 @@ func (d *decoder) decode(vs ...interface{}) error {
 
 			b := make([]byte, ll)
 			// must consume entire dir entry.
-			n, err := io.ReadFull(d.rd, b)
-			if err != nil {
-				log.Println("dir readfull failed:", err, ll, n)
+			if _, err := io.ReadFull(d.rd, b); err != nil {
 				return err
 			}
 

--- a/server.go
+++ b/server.go
@@ -79,7 +79,6 @@ func (c *conn) serve() error {
 	go c.read(requests)
 	go c.write(responses)
 
-	log.Println("server.run()")
 	for {
 		select {
 		case req := <-requests:
@@ -97,8 +96,6 @@ func (c *conn) serve() error {
 
 			switch msg := req.Message.(type) {
 			case MessageTflush:
-				log.Println("server: flushing message", msg.Oldtag)
-
 				var resp *Fcall
 				// check if we have actually know about the requested flush
 				active, ok := tags[msg.Oldtag]
@@ -167,7 +164,6 @@ func (c *conn) serve() error {
 				// the context was canceled for some reason, perhaps timeout or
 				// due to a flush call. We treat this as a condition where a
 				// response should not be sent.
-				log.Println("canceled", resp, active.ctx.Err())
 			}
 			delete(tags, resp.Tag)
 		case <-c.ctx.Done():
@@ -222,7 +218,7 @@ func (c *conn) write(responses chan *Fcall) {
 						// TODO(stevvooe): A full idle timeout on the
 						// connection should be enforced here. We log here,
 						// since this is less common.
-						log.Printf("9p server: temporary error writing fcall: %v", err)
+						log.Printf("p9p: temporary error writing fcall: %v", err)
 						continue
 					}
 				}

--- a/transport.go
+++ b/transport.go
@@ -128,7 +128,6 @@ func allocateTag(r *fcallRequest, m map[Tag]*fcallRequest, hint Tag) (Tag, error
 // handle takes messages off the wire and wakes up the waiting tag call.
 func (t *transport) handle() {
 	defer func() {
-		log.Println("exited handle loop")
 		close(t.closed)
 	}()
 
@@ -143,7 +142,6 @@ func (t *transport) handle() {
 	// loop to read messages off of the connection
 	go func() {
 		defer func() {
-			log.Println("exited read loop")
 			t.close() // single main loop
 		}()
 	loop:
@@ -161,7 +159,7 @@ func (t *transport) handle() {
 					}
 				}
 
-				log.Println("fatal error reading msg:", err)
+				log.Println("p9p: fatal error reading msg:", err)
 				return
 			}
 
@@ -169,7 +167,6 @@ func (t *transport) handle() {
 			case <-t.ctx.Done():
 				return
 			case <-t.closed:
-				log.Println("transport closed")
 				return
 			case responses <- fcall:
 			}


### PR DESCRIPTION
Ideally logging could be controlled by the user of the server via a struct field somewhere, but start by ensuring that the server only logs in exceptional cases and prefixes each log line with the package name.