### PR TITLE
Add link to the P9P protocl specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A modern, performant 9P library for Go.
 
 For information on usage, please see the [GoDoc](https://godoc.org/github.com/docker/go-p9p).
 
+Refer to [9P's documentation](http://9p.cat-v.org/documentation) for more details on the protocol.
+
 ## Copyright and license
 
 Copyright © 2015 Docker, Inc. go-p9p is licensed under the Apache License,


### PR DESCRIPTION
I thought it might be helpful to have a link directly to the spec...